### PR TITLE
NDPI-22: Add flow table max size support

### DIFF
--- a/ginetflow.h
+++ b/ginetflow.h
@@ -52,6 +52,7 @@ GInetFlow *g_inet_flow_expire(GInetFlowTable * table, guint64 ts);
 
 typedef void (*GIFFunc) (GInetFlow * flow, gpointer user_data);
 void g_inet_flow_foreach(GInetFlowTable * table, GIFFunc func, gpointer user_data);
+void g_inet_flow_table_max_set(GInetFlowTable * table, guint64 value);
 
 G_END_DECLS
 #endif                          /* __G_INET_FLOW_H__ */

--- a/test.c
+++ b/test.c
@@ -124,6 +124,31 @@ void test_flow_create()
     g_object_unref(table);
 }
 
+void test_flow_table_size()
+{
+    GInetFlowTable *table = g_inet_flow_table_new();
+    setup_test();
+    NP_ASSERT_NOT_NULL(table);
+
+    guint64 max;
+    g_object_get(table, "max", &max, NULL);
+    NP_ASSERT_EQUAL(max, 0);
+
+    g_inet_flow_table_max_set(table, 1);
+    g_object_get(table, "max", &max, NULL);
+    NP_ASSERT_EQUAL(max, 1);
+
+    guint pk1 = make_pkt(test_buffer, 4, IP_PROTOCOL_UDP);
+    GInetFlow *flow1 = g_inet_flow_get_full(table, test_buffer, pk1, 0, get_time_us(), TRUE);
+    NP_ASSERT_NOT_NULL(flow1);
+
+    guint pk2 = make_pkt(test_buffer, 4, IP_PROTOCOL_TCP);
+    GInetFlow *flow2 = g_inet_flow_get_full(table, test_buffer, pk2, 0, get_time_us(), TRUE);
+    NP_ASSERT_NULL(flow2);
+
+    g_object_unref(table);
+}
+
 void test_flow_not_expired()
 {
     guint64 now = get_time_us();


### PR DESCRIPTION
Add default table max of 0 for unlimited flow
table size.

Use g_inet_flow_table_max_set() to set the table size.

If the max number of flows is reached, NULL is returned
when creating a new flow.

Reviewed-by: Carl Smith <carl.smith@alliedtelesis.co.nz>