### PR TITLE
Use sockaddr_storage rather than gobjects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CC:=$(CROSS_COMPILE)gcc
 PKG_CONFIG ?= pkg-config
 GREP = grep --line-buffered --color=always
 
-CFLAGS = -fPIC -g -O2
+CFLAGS = -fPIC -g -O0
 
 EXTRA_CFLAGS = `$(PKG_CONFIG) --cflags glib-2.0 gio-2.0` -I.
 EXTRA_LDFLAGS = `$(PKG_CONFIG) --libs glib-2.0 gio-2.0` 

--- a/ginetflow.c
+++ b/ginetflow.c
@@ -26,6 +26,8 @@
 #include "ginetflow.h"
 #include "ginettuple.h"
 
+#include <netinet/in.h>
+
 #define DEBUG(fmt, args...)
 //#define DEBUG(fmt, args...) {g_printf("%s: ",__func__);g_printf (fmt, ## args);}
 #define CHECK_BIT(__v,__p) ((__v) & (1<<(__p)))
@@ -49,13 +51,13 @@ struct _GInetFlow {
     guint8 direction;
     guint16 server_port;
     guint32 server_ip[4];
-    GInetTuple *tuple;
+    GInetTuple tuple;
     gpointer context;
 };
 
 struct frag_info {
     guint32 id;
-    GInetTuple *tuple;
+    GInetTuple tuple;
     guint64 timestamp;
 };
 
@@ -234,9 +236,30 @@ static inline guint64 get_time_us(void)
     return (tv.tv_sec * (guint64) TIMESTAMP_RESOLUTION_US + tv.tv_usec);
 }
 
+static int address_comparison(struct sockaddr_storage *a, struct sockaddr_storage *b)
+{
+    if (((struct sockaddr_in*)a)->sin_family != ((struct sockaddr_in*)a)->sin_family)
+    {
+        return 1;
+    }
+
+    if (((struct sockaddr_in*)a)->sin_family == AF_INET)
+    {
+        struct sockaddr_in *a_v4 = (struct sockaddr_in *)a;
+        struct sockaddr_in *b_v4 = (struct sockaddr_in *)b;
+        return memcmp(&a_v4->sin_addr, &b_v4->sin_addr, sizeof(a_v4->sin_addr));
+    }
+    else
+    {
+        struct sockaddr_in6 *a_v6 = (struct sockaddr_in6 *)a;
+        struct sockaddr_in6 *b_v6 = (struct sockaddr_in6 *)b;
+        return memcmp(&a_v6->sin6_addr, &b_v6->sin6_addr, sizeof(a_v6->sin6_addr));
+    }
+}
+
 static int find_flow_by_frag_info(gconstpointer a, gconstpointer b)
 {
-    const struct frag_info *entry = a;
+    struct frag_info *entry = (struct frag_info*)a;
     struct frag_info *f = (struct frag_info *) b;
 
     if (entry->id != f->id) {
@@ -245,18 +268,16 @@ static int find_flow_by_frag_info(gconstpointer a, gconstpointer b)
 
     /* This is similar to g_inet_tuple_equal but ignores ports as they
      * are missing from the fragmented packet. */
-    GInetSocketAddress *lower = g_inet_tuple_get_lower(entry->tuple);
-    GInetSocketAddress *upper = g_inet_tuple_get_upper(entry->tuple);
-    GInetAddress *lower_a = g_inet_socket_address_get_address(lower);
-    GInetAddress *upper_a = g_inet_socket_address_get_address(upper);
+    struct sockaddr_storage *lower_a = g_inet_tuple_get_lower(&entry->tuple);
+    struct sockaddr_storage *upper_a = g_inet_tuple_get_upper(&entry->tuple);
 
-    GInetAddress *src_b = g_inet_tuple_get_src(f->tuple);
-    GInetAddress *dst_b = g_inet_tuple_get_dst(f->tuple);
+    struct sockaddr_storage *src_b = g_inet_tuple_get_lower(&f->tuple);
+    struct sockaddr_storage *dst_b = g_inet_tuple_get_upper(&f->tuple);
 
-    if (g_inet_address_equal(lower_a, src_b) && g_inet_address_equal(upper_a, dst_b)) {
+    if (address_comparison(lower_a, src_b) == 0 && address_comparison(upper_a, dst_b) == 0) {
         return 0;
     }
-    if (g_inet_address_equal(lower_a, dst_b) && g_inet_address_equal(upper_a, src_b)) {
+    if (address_comparison(lower_a, dst_b) == 0 && address_comparison(upper_a, src_b) == 0) {
         return 0;
     }
     return 1;
@@ -277,7 +298,6 @@ static guint16 clear_expired_frag_info(GList * frag_info_list, guint64 timestamp
         GList *next = l->next;
         if (frag_is_expired(l->data, timestamp)) {
             struct frag_info *frag_info = (struct frag_info *) (l->data);
-            g_object_unref(frag_info->tuple);
             free(l->data);
             frag_info_list = g_list_delete_link(frag_info_list, l);
             cleared += 1;
@@ -298,8 +318,7 @@ static gboolean store_frag_info(GList ** fragments, GInetTuple * f, guint64 ts, 
     }
     struct frag_info *entry = malloc(sizeof(struct frag_info));
     entry->id = id;
-    entry->tuple = f;
-    g_object_ref(entry->tuple);
+    entry->tuple = *f;
     entry->timestamp = timestamp;
     *fragments = g_list_prepend(*fragments, entry);
     return TRUE;
@@ -315,7 +334,7 @@ static guint16 flow_hash(GInetFlow * f)
     if (f->hash)
         return f->hash;
 
-    f->hash = g_inet_tuple_hash(f->tuple);
+    f->hash = g_inet_tuple_hash(&f->tuple);
 
     g_printf("%s", "");
 
@@ -325,7 +344,7 @@ static guint16 flow_hash(GInetFlow * f)
 
 static gboolean flow_compare(GInetFlow * f1, GInetFlow * f2)
 {
-    return g_inet_tuple_equal(f1->tuple, f2->tuple);
+    return g_inet_tuple_equal(&f1->tuple, &f2->tuple);
 }
 
 static gboolean flow_parse_tcp(GInetTuple * f, const guint8 * data, guint32 length,
@@ -337,8 +356,8 @@ static gboolean flow_parse_tcp(GInetTuple * f, const guint8 * data, guint32 leng
     guint16 sport = GUINT16_FROM_BE(tcp->source);
     guint16 dport = GUINT16_FROM_BE(tcp->destination);
 
-    g_inet_tuple_set_src_port(f, sport);
-    g_inet_tuple_set_dst_port(f, dport);
+    ((struct sockaddr_in*)&f->src)->sin_port = sport;
+    ((struct sockaddr_in*)&f->dst)->sin_port = dport;
 
     if (flags) {
         *flags = GUINT16_FROM_BE(tcp->flags);
@@ -354,8 +373,8 @@ static gboolean flow_parse_udp(GInetTuple * f, const guint8 * data, guint32 leng
     guint16 sport = GUINT16_FROM_BE(udp->source);
     guint16 dport = GUINT16_FROM_BE(udp->destination);
 
-    g_inet_tuple_set_src_port(f, sport);
-    g_inet_tuple_set_dst_port(f, dport);
+    ((struct sockaddr_in*)&f->src)->sin_port = sport;
+    ((struct sockaddr_in*)&f->dst)->sin_port = dport;
 
     return TRUE;
 }
@@ -368,8 +387,8 @@ static gboolean flow_parse_sctp(GInetTuple * f, const guint8 * data, guint32 len
     guint16 sport = GUINT16_FROM_BE(sctp->source);
     guint16 dport = GUINT16_FROM_BE(sctp->destination);
 
-    g_inet_tuple_set_src_port(f, sport);
-    g_inet_tuple_set_dst_port(f, dport);
+    ((struct sockaddr_in*)&f->src)->sin_port = sport;
+    ((struct sockaddr_in*)&f->dst)->sin_port = dport;
 
     return TRUE;
 }
@@ -419,14 +438,16 @@ static gboolean flow_parse_ipv4(GInetTuple * f, const guint8 * data, guint32 len
     if (length < sizeof(ip_hdr_t))
         return FALSE;
     if (iphr)
+    {
         *iphr = data;
+    }
 
-    g_inet_tuple_set_src_address(f,
-                                 g_inet_address_new_from_bytes((char *) &iph->saddr,
-                                                               G_SOCKET_FAMILY_IPV4));
-    g_inet_tuple_set_dst_address(f,
-                                 g_inet_address_new_from_bytes((char *) &iph->daddr,
-                                                               G_SOCKET_FAMILY_IPV4));
+    ((struct sockaddr_in*)&f->src)->sin_family = AF_INET;
+    ((struct sockaddr_in*)&f->dst)->sin_family = AF_INET;
+
+    memcpy(&((struct sockaddr_in*)&f->src)->sin_addr, (char *) &iph->saddr, sizeof(((struct sockaddr_in*)&f->src)->sin_addr));
+    memcpy(&((struct sockaddr_in*)&f->dst)->sin_addr, (char *) &iph->daddr, sizeof(((struct sockaddr_in*)&f->dst)->sin_addr));
+
     g_inet_tuple_set_protocol(f, iph->protocol);
 
     /* Non-first IP fragments (frag_offset is non-zero) will need a look-up
@@ -435,7 +456,7 @@ static gboolean flow_parse_ipv4(GInetTuple * f, const guint8 * data, guint32 len
     if (fragments && (GUINT16_FROM_BE(iph->frag_off) & 0x1FFF) != 0) {
         struct frag_info entry = { };
         entry.id = iph->id;
-        entry.tuple = f;
+        entry.tuple = *f;
 
         GList *match = g_list_find_custom(*fragments, &entry, find_flow_by_frag_info);
         if (!match)
@@ -443,17 +464,15 @@ static gboolean flow_parse_ipv4(GInetTuple * f, const guint8 * data, guint32 len
 
         struct frag_info *found_flow = match->data;
 
-        guint16 sport =
-            g_inet_socket_address_get_port(g_inet_tuple_get_lower(found_flow->tuple));
-        guint16 dport =
-            g_inet_socket_address_get_port(g_inet_tuple_get_upper(found_flow->tuple));
-        g_inet_tuple_set_src_port(f, sport);
-        g_inet_tuple_set_dst_port(f, dport);
+        guint16 sport = ((struct sockaddr_in*)g_inet_tuple_get_lower(&found_flow->tuple))->sin_port;
+        guint16 dport = ((struct sockaddr_in*)g_inet_tuple_get_upper(&found_flow->tuple))->sin_port;
+
+        ((struct sockaddr_in*)&f->src)->sin_port = sport;
+        ((struct sockaddr_in*)&f->dst)->sin_port = dport;
 
         /* If this is the last IP fragment (MF is unset), clean up */
         if ((GUINT16_FROM_BE(iph->frag_off) & 0x2000) == 0) {
             *fragments = g_list_remove(*fragments, found_flow);
-            g_object_unref(found_flow->tuple);
             free(found_flow);
         }
         return TRUE;
@@ -475,8 +494,8 @@ static gboolean flow_parse_ipv4(GInetTuple * f, const guint8 * data, guint32 len
         break;
     case IP_PROTOCOL_ICMP:
     default:
-        g_inet_tuple_set_src_port(f, 0);
-        g_inet_tuple_set_dst_port(f, 0);
+        ((struct sockaddr_in*)&f->src)->sin_port = 0;
+        ((struct sockaddr_in*)&f->dst)->sin_port = 0;
         break;
     }
 
@@ -503,12 +522,12 @@ static gboolean flow_parse_ipv6(GInetTuple * f, const guint8 * data, guint32 len
     if (iphr)
         *iphr = data;
 
-    g_inet_tuple_set_src_address(f,
-                                 g_inet_address_new_from_bytes(iph->saddr,
-                                                               G_SOCKET_FAMILY_IPV6));
-    g_inet_tuple_set_dst_address(f,
-                                 g_inet_address_new_from_bytes(iph->daddr,
-                                                               G_SOCKET_FAMILY_IPV6));
+    ((struct sockaddr_in*)&f->src)->sin_family = AF_INET6;
+    ((struct sockaddr_in*)&f->dst)->sin_family = AF_INET6;
+    memcpy(&((struct sockaddr_in6*)&f->src)->sin6_addr, (char *) &iph->saddr,
+            sizeof(((struct sockaddr_in6*)&f->src)->sin6_addr));
+    memcpy(&((struct sockaddr_in6*)&f->dst)->sin6_addr, (char *) &iph->daddr,
+            sizeof(((struct sockaddr_in6*)&f->dst)->sin6_addr));
     g_inet_tuple_set_protocol(f, iph->next_hdr);
 
     data += sizeof(ip6_hdr_t);
@@ -575,24 +594,23 @@ static gboolean flow_parse_ipv6(GInetTuple * f, const guint8 * data, guint32 len
         if (fragments && (GUINT16_FROM_BE(fragment_hdr->fo_res_mflag) & 0xFFF8) != 0) {
             struct frag_info entry = { };
             entry.id = fragment_hdr->id;
-            entry.tuple = f;
+            entry.tuple = *f;
 
             GList *match = g_list_find_custom(*fragments, &entry, find_flow_by_frag_info);
             if (!match)
+            {
                 return FALSE;
+            }
 
             struct frag_info *found_flow = match->data;
-            g_inet_tuple_set_src_port(f,
-                                      g_inet_socket_address_get_port(g_inet_tuple_get_lower
-                                                                     (found_flow->tuple)));
-            g_inet_tuple_set_dst_port(f,
-                                      g_inet_socket_address_get_port(g_inet_tuple_get_upper
-                                                                     (found_flow->tuple)));
+
+            /* Match source port / address etc - could be either way around */
+            ((struct sockaddr_in6*)&f->src)->sin6_port = ((struct sockaddr_in6*)&found_flow->tuple.src)->sin6_port;
+            ((struct sockaddr_in6*)&f->dst)->sin6_port = ((struct sockaddr_in6*)&found_flow->tuple.dst)->sin6_port;
 
             /* If this is the last IP fragment (MF is unset), clean up the list */
             if ((GUINT16_FROM_BE(fragment_hdr->fo_res_mflag) & 0x1) == 0) {
                 *fragments = g_list_remove(*fragments, found_flow);
-                g_object_unref(found_flow->tuple);
                 free(found_flow);
             }
             return TRUE;
@@ -612,8 +630,6 @@ static gboolean flow_parse_ipv6(GInetTuple * f, const guint8 * data, guint32 len
     case IP_PROTOCOL_NO_NEXT_HDR:
     case IP_PROTOCOL_ICMPV6:
     default:
-        g_inet_tuple_set_src_port(f, 0);
-        g_inet_tuple_set_dst_port(f, 0);
         break;
     }
 
@@ -787,36 +803,43 @@ static void g_inet_flow_get_property(GObject * object, guint prop_id,
         g_value_set_uint(value, flow->hash);
         break;
     case FLOW_PROTOCOL:
-        g_value_set_uint(value, g_inet_tuple_get_protocol(flow->tuple));
+        g_value_set_uint(value, g_inet_tuple_get_protocol(&flow->tuple));
         break;
     case FLOW_LPORT:
     case FLOW_SERVER_PORT:
         {
-            GInetSocketAddress *lower = g_inet_tuple_get_lower(flow->tuple);
-            g_value_set_uint(value, g_inet_socket_address_get_port(lower));
+            struct sockaddr_in *lower = (struct sockaddr_in *)g_inet_tuple_get_lower(&flow->tuple);
+            g_value_set_uint(value, lower->sin_port);
             break;
         }
     case FLOW_UPORT:
         {
-            GInetSocketAddress *upper = g_inet_tuple_get_upper(flow->tuple);
-            g_value_set_uint(value, g_inet_socket_address_get_port(upper));
+            struct sockaddr_in *upper = (struct sockaddr_in *)g_inet_tuple_get_upper(&flow->tuple);
+            g_value_set_uint(value, upper->sin_port);
             break;
         }
     case FLOW_LIP:
     case FLOW_SERVER_IP:
         {
-            GInetSocketAddress *lower = g_inet_tuple_get_lower(flow->tuple);
-            gchar *str = g_inet_address_to_string(g_inet_socket_address_get_address(lower));
+            char str[INET6_ADDRSTRLEN];
+            struct sockaddr_in *lower = (struct sockaddr_in*)g_inet_tuple_get_lower(&flow->tuple);
+            if (lower->sin_family == AF_INET)
+                inet_ntop(AF_INET, &lower->sin_addr, str, sizeof(str));
+            else
+                inet_ntop(AF_INET6, &((struct sockaddr_in6*)lower)->sin6_addr, str, sizeof(str));
             g_value_set_string(value, str);
-            g_free(str);
+
             break;
         }
     case FLOW_UIP:
         {
-            GInetSocketAddress *upper = g_inet_tuple_get_upper(flow->tuple);
-            gchar *str = g_inet_address_to_string(g_inet_socket_address_get_address(upper));
+            char str[INET6_ADDRSTRLEN];
+            struct sockaddr_in *upper = (struct sockaddr_in*)g_inet_tuple_get_upper(&flow->tuple);
+            if (upper->sin_family == AF_INET)
+                inet_ntop(AF_INET, &upper->sin_addr, str, sizeof(str));
+            else
+                inet_ntop(AF_INET6, &((struct sockaddr_in6*)upper)->sin6_addr, str, sizeof(str));
             g_value_set_string(value, str);
-            g_free(str);
             break;
         }
     default:
@@ -831,8 +854,6 @@ static void g_inet_flow_finalize(GObject * object)
     int index = find_expiry_index(flow->lifetime);
     g_queue_unlink(flow->table->expire_queue[index], &flow->list);
     g_hash_table_remove(flow->table->table, flow);
-    if (flow->tuple)
-        g_object_unref(flow->tuple);
     G_OBJECT_CLASS(g_inet_flow_parent_class)->finalize(object);
 }
 
@@ -923,15 +944,16 @@ void g_inet_flow_update_udp(GInetFlow * flow, GInetFlow * packet)
 
 void g_inet_flow_update(GInetFlow * flow, GInetFlow * packet)
 {
-    if (g_inet_tuple_get_protocol(flow->tuple) == IP_PROTOCOL_TCP) {
+    if (g_inet_tuple_get_protocol(&flow->tuple) == IP_PROTOCOL_TCP) {
         g_inet_flow_update_tcp(flow, packet);
-    } else if (g_inet_tuple_get_protocol(flow->tuple) == IP_PROTOCOL_UDP) {
+    } else if (g_inet_tuple_get_protocol(&flow->tuple) == IP_PROTOCOL_UDP) {
         g_inet_flow_update_udp(flow, packet);
     }
 }
 
 static void g_inet_flow_init(GInetFlow * flow)
 {
+    memset(&flow->tuple, 0, sizeof(flow->tuple));
     flow->state = FLOW_NEW;
 }
 
@@ -964,18 +986,18 @@ GInetFlow *g_inet_flow_get_full(GInetFlowTable * table,
                                 gboolean l2, const uint8_t ** iphr)
 {
     GInetFlow packet = {.timestamp = timestamp };
-    GInetTuple *tuple = (GInetTuple *) g_object_new(G_INET_TUPLE_TYPE, NULL);
+    GInetTuple tuple = { 0 };
     GInetFlow *flow = NULL;
 
     if (l2) {
         if (!flow_parse
-            (tuple, frame, length, hash, &table->frag_info_list, iphr, timestamp,
+            (&tuple, frame, length, hash, &table->frag_info_list, iphr, timestamp,
              &packet.flags)) {
             goto exit;
         }
     } else
         if (!flow_parse_ip
-            (tuple, frame, length, hash, &table->frag_info_list, iphr, timestamp,
+            (&tuple, frame, length, hash, &table->frag_info_list, iphr, timestamp,
              &packet.flags)) {
         goto exit;
     }
@@ -1007,7 +1029,6 @@ GInetFlow *g_inet_flow_get_full(GInetFlowTable * table,
         flow->direction = packet.direction;
         flow->hash = packet.hash;
         flow->tuple = packet.tuple;
-        g_object_ref(flow->tuple);
         flow->server_port = packet.server_port;
         memcpy(flow->server_ip, packet.server_ip, sizeof(packet.server_ip));
         g_hash_table_replace(table->table, (gpointer) flow, (gpointer) flow);
@@ -1019,7 +1040,6 @@ GInetFlow *g_inet_flow_get_full(GInetFlowTable * table,
     }
   exit:
 
-    g_object_unref(tuple);
     return flow;
 }
 
@@ -1118,9 +1138,10 @@ void g_inet_flow_foreach(GInetFlowTable * table, GIFFunc func, gpointer user_dat
     }
 }
 
-GInetTuple *g_inet_flow_parse(const guint8 * frame, guint length, GList ** fragments)
+GInetTuple *g_inet_flow_parse(const guint8 * frame, guint length, GList ** fragments, GInetTuple *result)
 {
-    GInetTuple *result = (GInetTuple *) g_object_new(G_INET_TUPLE_TYPE, NULL);
+    if (!result)
+        result = calloc(1, sizeof(GInetTuple));
     flow_parse(result, frame, length, 0, fragments, NULL, 0, NULL);
     return result;
 }

--- a/ginetflow.h
+++ b/ginetflow.h
@@ -52,7 +52,9 @@ GInetFlow *g_inet_flow_get_full(GInetFlowTable * table, const guint8 * frame,
                                 gboolean update, gboolean l2, const uint8_t ** iphr);
 GInetFlow *g_inet_flow_expire(GInetFlowTable * table, guint64 ts);
 
-GInetTuple *g_inet_flow_parse(const guint8 * frame, guint length, GList ** fragments);
+/* g_inet_flow_parse will populate result if result is not null, otherwise it will malloc a structure
+ * to return. */
+GInetTuple *g_inet_flow_parse(const guint8 * frame, guint length, GList ** fragments, GInetTuple *result);
 
 typedef void (*GIFFunc) (GInetFlow * flow, gpointer user_data);
 void g_inet_flow_foreach(GInetFlowTable * table, GIFFunc func, gpointer user_data);

--- a/ginettuple.c
+++ b/ginettuple.c
@@ -93,42 +93,23 @@ static int sock_address_comparison(struct sockaddr_storage *a, struct sockaddr_s
 
 gboolean g_inet_tuple_equal(GInetTuple * a, GInetTuple * b)
 {
+    if (a->protocol != b->protocol) {
+        return FALSE;
+    }
+
     struct sockaddr_storage *lower_a = g_inet_tuple_get_lower(a);
     struct sockaddr_storage *upper_a = g_inet_tuple_get_upper(a);
     struct sockaddr_storage *lower_b = g_inet_tuple_get_lower(b);
     struct sockaddr_storage *upper_b = g_inet_tuple_get_upper(b);
-    gboolean equal = FALSE;
 
-    if (!lower_a || !upper_a || !lower_b || !upper_b) {
-        goto exit;
-    }
-    if (a->protocol != b->protocol) {
-        goto exit;
-    }
     if (sock_address_comparison(lower_a, lower_b)) {
-        goto exit;
+        return FALSE;
     }
     if (sock_address_comparison(upper_a, upper_b)) {
-        goto exit;
+        return FALSE;
     }
-    equal = TRUE;
-  exit:
-    return equal;
-}
 
-static inline guint16 crc16(guint16 iv, guint64 p)
-{
-    int i;
-    int j;
-    guint32 b;
-    guint16 poly = 0x1021;
-    for (i = 7; i >= 0; i--) {
-        b = (p >> (i * 8)) & 0xff;
-        for (j = 7; j >= 0; j--) {
-            iv = ((iv << 1) ^ ((((iv >> 15) & 1) ^ ((b >> j) & 1)) ? poly : 0)) & 0xffff;
-        }
-    }
-    return iv;
+    return TRUE;
 }
 
 guint g_inet_tuple_hash(GInetTuple * tuple)
@@ -140,32 +121,14 @@ guint g_inet_tuple_hash(GInetTuple * tuple)
     guint16 prot_crc = 0xffff;
 
     if (tuple->hash)
-        return hash;
+    {
+        return tuple->hash;
+    }
 
     struct sockaddr_storage *lower = g_inet_tuple_get_lower(tuple);
     struct sockaddr_storage *upper = g_inet_tuple_get_upper(tuple);
 
-    if (lower->ss_family == AF_INET)
-    {
-        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in*)lower)->sin_addr.s_addr) << 32);
-        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in*)lower)->sin_port) << 48);
-        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in*)upper)->sin_addr.s_addr) << 32);
-        dst_crc = crc16(dst_crc, ((guint64) ((struct sockaddr_in*)upper)->sin_port) << 48);
-    }
-    else
-    {
-        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in6*)lower)->sin6_addr.s6_addr32[0]) << 32 | ((struct sockaddr_in6*)lower)->sin6_addr.s6_addr32[1]);
-        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in6*)lower)->sin6_addr.s6_addr32[2]) << 32 | ((struct sockaddr_in6*)lower)->sin6_addr.s6_addr32[3]);
-        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in6*)lower)->sin6_port) << 48);
-        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in6*)upper)->sin6_addr.s6_addr32[0]) << 32 | ((struct sockaddr_in6*)upper)->sin6_addr.s6_addr32[1]);
-        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in6*)upper)->sin6_addr.s6_addr32[2]) << 32 | ((struct sockaddr_in6*)upper)->sin6_addr.s6_addr32[3]);
-        dst_crc = crc16(dst_crc, ((guint64) ((struct sockaddr_in6*)upper)->sin6_port) << 48);
-    }
+    tuple->hash = ((struct sockaddr_in*)lower)->sin_port << 16 | ((struct sockaddr_in*)upper)->sin_port;
 
-
-    prot_crc = crc16(prot_crc, ((guint64) g_inet_tuple_get_protocol(tuple)) << 56);
-    hash = (src_crc ^ dst_crc ^ prot_crc);
-
-    tuple->hash = hash;
-    return hash;
+    return tuple->hash;
 }

--- a/ginettuple.c
+++ b/ginettuple.c
@@ -17,74 +17,21 @@
  */
 
 #include "ginettuple.h"
-
-/** GInetTuple */
-struct _GInetTuple {
-    GObject parent;
-    GInetAddress *src;
-    guint16 sport;
-    GInetAddress *dst;
-    guint16 dport;
-    guint16 protocol;
-
-    /* Internal use only */
-    GInetSocketAddress *lower;
-    GInetSocketAddress *upper;
-};
-
-struct _GInetTupleClass {
-    GObjectClass parent;
-};
-G_DEFINE_TYPE(GInetTuple, g_inet_tuple, G_TYPE_OBJECT);
+#include <string.h>
 
 void clear_cached(GInetTuple * tuple)
 {
-    if (tuple->lower) {
-        g_object_unref(tuple->lower);
-        tuple->lower = NULL;
-    }
-    if (tuple->upper) {
-        g_object_unref(tuple->upper);
-        tuple->upper = NULL;
-    }
+    tuple->hash = 0;
 }
 
-GInetAddress *g_inet_tuple_get_src(GInetTuple * tuple)
+struct sockaddr_storage *g_inet_tuple_get_src(GInetTuple * tuple)
 {
-    return tuple->src;
+    return &tuple->src;
 }
 
-GInetAddress *g_inet_tuple_get_dst(GInetTuple * tuple)
+struct sockaddr_storage *g_inet_tuple_get_dst(GInetTuple * tuple)
 {
-    return tuple->dst;
-}
-
-void g_inet_tuple_set_src_address(GInetTuple * tuple, GInetAddress * src)
-{
-    if (tuple->src)
-        g_object_unref((GObject *) tuple->src);
-    clear_cached(tuple);
-    tuple->src = src;
-}
-
-void g_inet_tuple_set_src_port(GInetTuple * tuple, guint16 port)
-{
-    tuple->sport = port;
-    clear_cached(tuple);
-}
-
-void g_inet_tuple_set_dst_address(GInetTuple * tuple, GInetAddress * dst)
-{
-    if (tuple->dst)
-        g_object_unref((GObject *) tuple->dst);
-    clear_cached(tuple);
-    tuple->dst = dst;
-}
-
-void g_inet_tuple_set_dst_port(GInetTuple * tuple, guint16 port)
-{
-    tuple->dport = port;
-    clear_cached(tuple);
+    return &tuple->dst;
 }
 
 void g_inet_tuple_set_protocol(GInetTuple * tuple, guint16 protocol)
@@ -92,50 +39,28 @@ void g_inet_tuple_set_protocol(GInetTuple * tuple, guint16 protocol)
     tuple->protocol = protocol;
 }
 
-GInetSocketAddress *g_inet_tuple_get_lower(GInetTuple * tuple)
+struct sockaddr_storage *g_inet_tuple_get_lower(GInetTuple * tuple)
 {
-    GInetAddress *src = g_inet_tuple_get_src(tuple);
-    GInetAddress *dst = g_inet_tuple_get_dst(tuple);
-
-    if (!src || !dst)
-        return NULL;
-
-    if (tuple->lower)
-        return tuple->lower;
-
-    if (tuple->sport > tuple->dport) {
-        tuple->lower = (GInetSocketAddress *) g_inet_socket_address_new(dst, tuple->dport);
-    } else {
-        tuple->lower = (GInetSocketAddress *) g_inet_socket_address_new(src, tuple->sport);
-    }
-    return tuple->lower;
+    if (((struct sockaddr_in*)&tuple->src)->sin_port < ((struct sockaddr_in*)&tuple->dst)->sin_port)
+        return &tuple->src;
+    else
+        return &tuple->dst;
 }
 
-GInetSocketAddress *g_inet_tuple_get_upper(GInetTuple * tuple)
+struct sockaddr_storage *g_inet_tuple_get_upper(GInetTuple * tuple)
 {
-    GInetAddress *src = g_inet_tuple_get_src(tuple);
-    GInetAddress *dst = g_inet_tuple_get_dst(tuple);
-
-    if (!src || !dst)
-        return NULL;
-
-    if (tuple->upper)
-        return tuple->upper;
-
-    if (tuple->sport <= tuple->dport) {
-        tuple->upper = (GInetSocketAddress *) g_inet_socket_address_new(dst, tuple->dport);
-    } else {
-        tuple->upper = (GInetSocketAddress *) g_inet_socket_address_new(src, tuple->sport);
-    }
-    return tuple->upper;
+    if (((struct sockaddr_in*)&tuple->src)->sin_port >= ((struct sockaddr_in*)&tuple->dst)->sin_port)
+        return &tuple->src;
+    else
+        return &tuple->dst;
 }
 
-GInetSocketAddress *g_inet_tuple_get_server(GInetTuple * tuple)
+struct sockaddr_storage *g_inet_tuple_get_server(GInetTuple * tuple)
 {
     return g_inet_tuple_get_lower(tuple);
 }
 
-GInetSocketAddress *g_inet_tuple_get_client(GInetTuple * tuple)
+struct sockaddr_storage *g_inet_tuple_get_client(GInetTuple * tuple)
 {
     return g_inet_tuple_get_upper(tuple);
 }
@@ -145,31 +70,33 @@ guint16 g_inet_tuple_get_protocol(GInetTuple * tuple)
     return tuple->protocol;
 }
 
-/* This function is a candidate for going upstream into GInetSocketAddress */
-gboolean g_inet_socket_address_equal(GInetSocketAddress * a, GInetSocketAddress * b)
+static int sock_address_comparison(struct sockaddr_storage *a, struct sockaddr_storage *b)
 {
-    if (!a && b) {
-        return FALSE;
+    if (((struct sockaddr_in*)a)->sin_family != ((struct sockaddr_in*)a)->sin_family)
+    {
+        return 1;
     }
-    if (a && !b) {
-        return FALSE;
+
+    if (((struct sockaddr_in*)a)->sin_family == AF_INET)
+    {
+        struct sockaddr_in *a_v4 = (struct sockaddr_in *)a;
+        struct sockaddr_in *b_v4 = (struct sockaddr_in *)b;
+        return memcmp(&a_v4->sin_addr, &b_v4->sin_addr, sizeof(a_v4->sin_addr));
     }
-    if (g_inet_socket_address_get_port(a) != g_inet_socket_address_get_port(b)) {
-        return FALSE;
+    else
+    {
+        struct sockaddr_in6 *a_v6 = (struct sockaddr_in6 *)a;
+        struct sockaddr_in6 *b_v6 = (struct sockaddr_in6 *)b;
+        return memcmp(&a_v6->sin6_addr, &b_v6->sin6_addr, sizeof(a_v6->sin6_addr));
     }
-    if (!g_inet_address_equal
-        (g_inet_socket_address_get_address(a), g_inet_socket_address_get_address(b))) {
-        return FALSE;
-    }
-    return TRUE;
 }
 
 gboolean g_inet_tuple_equal(GInetTuple * a, GInetTuple * b)
 {
-    GInetSocketAddress *lower_a = g_inet_tuple_get_lower(a);
-    GInetSocketAddress *upper_a = g_inet_tuple_get_upper(a);
-    GInetSocketAddress *lower_b = g_inet_tuple_get_lower(b);
-    GInetSocketAddress *upper_b = g_inet_tuple_get_upper(b);
+    struct sockaddr_storage *lower_a = g_inet_tuple_get_lower(a);
+    struct sockaddr_storage *upper_a = g_inet_tuple_get_upper(a);
+    struct sockaddr_storage *lower_b = g_inet_tuple_get_lower(b);
+    struct sockaddr_storage *upper_b = g_inet_tuple_get_upper(b);
     gboolean equal = FALSE;
 
     if (!lower_a || !upper_a || !lower_b || !upper_b) {
@@ -178,10 +105,10 @@ gboolean g_inet_tuple_equal(GInetTuple * a, GInetTuple * b)
     if (a->protocol != b->protocol) {
         goto exit;
     }
-    if (!g_inet_socket_address_equal(lower_a, lower_b)) {
+    if (sock_address_comparison(lower_a, lower_b)) {
         goto exit;
     }
-    if (!g_inet_socket_address_equal(upper_a, upper_b)) {
+    if (sock_address_comparison(upper_a, upper_b)) {
         goto exit;
     }
     equal = TRUE;
@@ -212,51 +139,33 @@ guint g_inet_tuple_hash(GInetTuple * tuple)
     guint16 dst_crc = 0xffff;
     guint16 prot_crc = 0xffff;
 
-    GInetSocketAddress *lower = g_inet_tuple_get_lower(tuple);
-    GInetSocketAddress *upper = g_inet_tuple_get_upper(tuple);
+    if (tuple->hash)
+        return hash;
 
-    guint32 *lower_ip =
-        (guint32 *) g_inet_address_to_bytes(g_inet_socket_address_get_address(lower));
-    guint32 *upper_ip =
-        (guint32 *) g_inet_address_to_bytes(g_inet_socket_address_get_address(upper));
+    struct sockaddr_storage *lower = g_inet_tuple_get_lower(tuple);
+    struct sockaddr_storage *upper = g_inet_tuple_get_upper(tuple);
 
-    src_crc = crc16(src_crc, ((guint64) lower_ip[0]) << 32 | lower_ip[1]);
-    src_crc = crc16(src_crc, ((guint64) lower_ip[2]) << 32 | lower_ip[3]);
-    src_crc = crc16(src_crc, ((guint64) g_inet_socket_address_get_port(lower)) << 48);
-    dst_crc = crc16(dst_crc, ((guint64) upper_ip[0]) << 32 | upper_ip[1]);
-    dst_crc = crc16(dst_crc, ((guint64) upper_ip[2]) << 32 | upper_ip[3]);
-    dst_crc = crc16(dst_crc, ((guint64) g_inet_socket_address_get_port(upper)) << 48);
+    if (lower->ss_family == AF_INET)
+    {
+        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in*)lower)->sin_addr.s_addr) << 32);
+        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in*)lower)->sin_port) << 48);
+        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in*)upper)->sin_addr.s_addr) << 32);
+        dst_crc = crc16(dst_crc, ((guint64) ((struct sockaddr_in*)upper)->sin_port) << 48);
+    }
+    else
+    {
+        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in6*)lower)->sin6_addr.s6_addr32[0]) << 32 | ((struct sockaddr_in6*)lower)->sin6_addr.s6_addr32[1]);
+        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in6*)lower)->sin6_addr.s6_addr32[2]) << 32 | ((struct sockaddr_in6*)lower)->sin6_addr.s6_addr32[3]);
+        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in6*)lower)->sin6_port) << 48);
+        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in6*)upper)->sin6_addr.s6_addr32[0]) << 32 | ((struct sockaddr_in6*)upper)->sin6_addr.s6_addr32[1]);
+        src_crc = crc16(src_crc, ((guint64) ((struct sockaddr_in6*)upper)->sin6_addr.s6_addr32[2]) << 32 | ((struct sockaddr_in6*)upper)->sin6_addr.s6_addr32[3]);
+        dst_crc = crc16(dst_crc, ((guint64) ((struct sockaddr_in6*)upper)->sin6_port) << 48);
+    }
+
 
     prot_crc = crc16(prot_crc, ((guint64) g_inet_tuple_get_protocol(tuple)) << 56);
     hash = (src_crc ^ dst_crc ^ prot_crc);
+
+    tuple->hash = hash;
     return hash;
-}
-
-static void g_inet_tuple_init(GInetTuple * tuple)
-{
-    tuple->src = NULL;
-    tuple->dst = NULL;
-    tuple->upper = NULL;
-    tuple->lower = NULL;
-    return;
-}
-
-static void g_inet_tuple_dispose(GObject * gobject)
-{
-    GInetTuple *tuple = (GInetTuple *) gobject;
-    if (tuple->src)
-        g_object_unref(tuple->src);
-    if (tuple->dst)
-        g_object_unref(tuple->dst);
-    if (tuple->lower)
-        g_object_unref(tuple->lower);
-    if (tuple->upper)
-        g_object_unref(tuple->upper);
-}
-
-static void g_inet_tuple_class_init(GInetTupleClass * class)
-{
-    GObjectClass *object_class = G_OBJECT_CLASS(class);
-    object_class->dispose = g_inet_tuple_dispose;
-    return;
 }

--- a/ginettuple.h
+++ b/ginettuple.h
@@ -22,26 +22,24 @@
 #include <glib.h>
 #include <gio/gio.h>
 
+#include <netinet/in.h>
 
-G_BEGIN_DECLS GType g_inet_tuple_get_type(void) G_GNUC_CONST;
-#define G_INET_TUPLE_TYPE      (g_inet_tuple_get_type ())
-typedef struct _GInetTuple GInetTuple;
-typedef struct _GInetTupleClass GInetTupleClass;
-#define G_INET_TUPLE(o)        (G_TYPE_CHECK_INSTANCE_CAST ((o), G_INET_TUPLE_TYPE, GInetTuple))
+typedef struct _GInetTuple {
+    struct sockaddr_storage src;
+    struct sockaddr_storage dst;
+    guint16 protocol;
 
-GInetAddress *g_inet_tuple_get_src(GInetTuple * tuple);
-/* g_inet_tuple_set_src_address owns src after this call */
-void g_inet_tuple_set_src_address(GInetTuple * tuple, GInetAddress * src);
-void g_inet_tuple_set_src_port(GInetTuple * tuple, guint16 port);
-GInetAddress *g_inet_tuple_get_dst(GInetTuple * tuple);
-/* g_inet_tuple_set_dst_address owns dst after this call */
-void g_inet_tuple_set_dst_address(GInetTuple * tuple, GInetAddress * dst);
-void g_inet_tuple_set_dst_port(GInetTuple * tuple, guint16 port);
+    /* Internal use only */
+    guint hash;
+} GInetTuple;
+
+struct sockaddr_storage *g_inet_tuple_get_src(GInetTuple * tuple);
+struct sockaddr_storage *g_inet_tuple_get_dst(GInetTuple * tuple);
+struct sockaddr_storage *g_inet_tuple_get_lower(GInetTuple * tuple);
+struct sockaddr_storage *g_inet_tuple_get_upper(GInetTuple * tuple);
+struct sockaddr_storage *g_inet_tuple_get_server(GInetTuple * tuple);
+struct sockaddr_storage *g_inet_tuple_get_client(GInetTuple * tuple);
 void g_inet_tuple_set_protocol(GInetTuple * tuple, guint16 protocol);
-GInetSocketAddress *g_inet_tuple_get_lower(GInetTuple * tuple);
-GInetSocketAddress *g_inet_tuple_get_upper(GInetTuple * tuple);
-GInetSocketAddress *g_inet_tuple_get_server(GInetTuple * tuple);
-GInetSocketAddress *g_inet_tuple_get_client(GInetTuple * tuple);
 guint16 g_inet_tuple_get_protocol(GInetTuple * tuple);
 gboolean g_inet_tuple_equal(GInetTuple * a, GInetTuple * b);
 guint g_inet_tuple_hash(GInetTuple * t);

--- a/test.c
+++ b/test.c
@@ -20,7 +20,7 @@
 #include <arpa/inet.h>
 #include <np.h>
 
-static GInetTuple *test_tuple;
+static GInetTuple *test_tuple = NULL;
 #define MAX_BUFFER_SIZE     1600
 
 #define TEST_SPORT 0x1111
@@ -542,9 +542,7 @@ static guint make_pkt_gre(guint8 * buffer, guint16 eth_protocol, guint16 gre_pro
 
 static void setup_test()
 {
-    if (test_tuple)
-        g_object_unref(test_tuple);
-    test_tuple = (GInetTuple *) g_object_new(G_INET_TUPLE_TYPE, NULL);
+    test_tuple = calloc(1, sizeof(*test_tuple));
     memset(test_buffer, 0, MAX_BUFFER_SIZE);
 }
 
@@ -578,7 +576,7 @@ void test_flow_parse_udp()
 {
     setup_test();
 
-    GInetTuple *test = (GInetTuple *) g_object_new(G_INET_TUPLE_TYPE, NULL);
+    GInetTuple *test = calloc(1, sizeof(GInetTuple));
     guint len = make_pkt(test_buffer, ETH_PROTOCOL_IP, IP_PROTOCOL_UDP);
     NP_ASSERT(flow_parse(test, test_buffer, len, 0, NULL, NULL, 0, NULL));
 
@@ -591,7 +589,7 @@ void test_flow_parse_udp()
 
     len = make_pkt_reverse(test_buffer, ETH_PROTOCOL_IPV6, IP_PROTOCOL_UDP);
     NP_ASSERT(flow_parse(test, test_buffer, len, 0, NULL, NULL, 0, NULL));
-    g_object_unref(test);
+    free(test);
 }
 
 void test_flow_parse_tcp()
@@ -2118,73 +2116,3 @@ void test_flow_expiry_queue()
     g_object_unref(table);
 }
 
-
-void test_tuple_creation()
-{
-    GInetTuple *tuple = g_object_new(G_INET_TUPLE_TYPE, NULL);
-    NP_ASSERT_NULL(g_inet_tuple_get_src(tuple));
-    NP_ASSERT_NULL(g_inet_tuple_get_dst(tuple));
-    NP_ASSERT_NULL(g_inet_tuple_get_lower(tuple));
-    NP_ASSERT_NULL(g_inet_tuple_get_upper(tuple));
-    g_object_unref(tuple);
-}
-
-void test_tuple_get_addresses()
-{
-    GInetTuple *tuple = g_object_new(G_INET_TUPLE_TYPE, NULL);
-    GInetAddress *src = g_inet_address_new_from_string("192.168.1.1");
-    GInetAddress *dst = g_inet_address_new_from_string("192.168.1.2");
-    g_inet_tuple_set_src_address(tuple, src);
-    g_inet_tuple_set_dst_address(tuple, dst);
-    NP_ASSERT(g_inet_address_equal(src, g_inet_tuple_get_src(tuple)));
-    NP_ASSERT(g_inet_address_equal(dst, g_inet_tuple_get_dst(tuple)));
-    g_object_unref(tuple);
-}
-
-void test_tuple_get_endpoints()
-{
-    GInetTuple *tuple = g_object_new(G_INET_TUPLE_TYPE, NULL);
-    GInetAddress *src = g_inet_address_new_from_string("192.168.1.1");
-    GInetAddress *dst = g_inet_address_new_from_string("192.168.1.2");
-    g_inet_tuple_set_src_address(tuple, src);
-    g_inet_tuple_set_src_port(tuple, 12345);
-    g_inet_tuple_set_dst_address(tuple, dst);
-    g_inet_tuple_set_dst_port(tuple, 80);
-
-    GInetSocketAddress *lower = g_inet_tuple_get_lower(tuple);
-    GInetSocketAddress *upper = g_inet_tuple_get_upper(tuple);
-    GInetSocketAddress *server = g_inet_tuple_get_server(tuple);
-
-    NP_ASSERT(g_inet_socket_address_get_port(lower) == 80);
-    NP_ASSERT(g_inet_socket_address_get_port(upper) == 12345);
-    NP_ASSERT(g_inet_address_equal(g_inet_socket_address_get_address(lower), dst));
-    NP_ASSERT(g_inet_address_equal(g_inet_socket_address_get_address(upper), src));
-    NP_ASSERT(g_inet_socket_address_equal(server, lower));
-    NP_ASSERT(!g_inet_socket_address_equal(server, upper));
-
-    g_object_unref(tuple);
-}
-
-void test_tuple_get_ipv6_endpoints()
-{
-    GInetTuple *tuple = g_object_new(G_INET_TUPLE_TYPE, NULL);
-    GInetAddress *src = g_inet_address_new_from_string("fc00:1::1");
-    GInetAddress *dst = g_inet_address_new_from_string("fc00:1::2");
-    g_inet_tuple_set_src_address(tuple, src);
-    g_inet_tuple_set_src_port(tuple, 12345);
-    g_inet_tuple_set_dst_address(tuple, dst);
-    g_inet_tuple_set_dst_port(tuple, 80);
-
-    GInetSocketAddress *lower = g_inet_tuple_get_lower(tuple);
-    GInetSocketAddress *upper = g_inet_tuple_get_upper(tuple);
-    GInetSocketAddress *server = g_inet_tuple_get_server(tuple);
-
-    NP_ASSERT(g_inet_socket_address_get_port(lower) == 80);
-    NP_ASSERT(g_inet_socket_address_get_port(upper) == 12345);
-    NP_ASSERT(g_inet_address_equal(g_inet_socket_address_get_address(lower), dst));
-    NP_ASSERT(g_inet_address_equal(g_inet_socket_address_get_address(upper), src));
-    NP_ASSERT(g_inet_socket_address_equal(server, lower));
-    NP_ASSERT(!g_inet_socket_address_equal(server, upper));
-
-    g_object_unref(tuple);
-}


### PR DESCRIPTION
The overhead required for GInetAddress / GInetSocketAddress is too
great, moved GInetTuple to expose two sockaddr_storage structures
that can be manipulated with inet_ functions.