### PR TITLE
Improve performance when fetching IP addresses from flows

### DIFF
--- a/ginetflow.c
+++ b/ginetflow.c
@@ -707,29 +707,16 @@ static void g_inet_flow_get_property(GObject * object, guint prop_id,
     case FLOW_LIP:
     case FLOW_SERVER_IP:
         {
-            char str[INET6_ADDRSTRLEN];
             struct sockaddr_in *lower =
                 (struct sockaddr_in *) g_inet_tuple_get_lower(&flow->tuple);
-            if (lower->sin_family == AF_INET)
-                inet_ntop(AF_INET, &lower->sin_addr, str, sizeof(str));
-            else
-                inet_ntop(AF_INET6, &((struct sockaddr_in6 *) lower)->sin6_addr, str,
-                          sizeof(str));
-            g_value_set_string(value, str);
-
+            g_value_set_pointer(value, lower);
             break;
         }
     case FLOW_UIP:
         {
-            char str[INET6_ADDRSTRLEN];
             struct sockaddr_in *upper =
                 (struct sockaddr_in *) g_inet_tuple_get_upper(&flow->tuple);
-            if (upper->sin_family == AF_INET)
-                inet_ntop(AF_INET, &upper->sin_addr, str, sizeof(str));
-            else
-                inet_ntop(AF_INET6, &((struct sockaddr_in6 *) upper)->sin6_addr, str,
-                          sizeof(str));
-            g_value_set_string(value, str);
+            g_value_set_pointer(value, upper);
             break;
         }
     default:
@@ -782,17 +769,17 @@ static void g_inet_flow_class_init(GInetFlowClass * class)
                                                       "Server port (lower port)",
                                                       0, G_MAXUINT16, 0, G_PARAM_READABLE));
     g_object_class_install_property(object_class, FLOW_LIP,
-                                    g_param_spec_string("lip", "LIP",
-                                                        "Lower IP address (smaller value)",
-                                                        NULL, G_PARAM_READABLE));
+                                    g_param_spec_pointer("lip", "LIP",
+                                                         "Lower IP address (smaller value)",
+                                                         G_PARAM_READABLE));
     g_object_class_install_property(object_class, FLOW_UIP,
-                                    g_param_spec_string("uip", "UIP",
-                                                        "Upper IP address (larger value)",
-                                                        NULL, G_PARAM_READABLE));
+                                    g_param_spec_pointer("uip", "UIP",
+                                                         "Upper IP address (larger value)",
+                                                         G_PARAM_READABLE));
     g_object_class_install_property(object_class, FLOW_SERVER_IP,
-                                    g_param_spec_string("serverip", "ServerIP",
-                                                        "Server IP address (device with lower port)",
-                                                        NULL, G_PARAM_READABLE));
+                                    g_param_spec_pointer("serverip", "ServerIP",
+                                                         "Server IP address (device with lower port)",
+                                                         G_PARAM_READABLE));
     object_class->finalize = g_inet_flow_finalize;
 }
 

--- a/test.c
+++ b/test.c
@@ -1076,11 +1076,9 @@ void test_flow_properties()
     guint lport;
     guint uport;
     guint server_port;
-    gchar *lip;
-    gchar *uip;
-    gchar *sip;
-    gchar *saddr_c = NULL;
-    gchar *daddr_c = NULL;
+    struct sockaddr_storage *lip;
+    struct sockaddr_storage *uip;
+    struct sockaddr_storage *sip;
 
 
     setup_test();
@@ -1113,17 +1111,11 @@ void test_flow_properties()
     NP_ASSERT_NOT_NULL(lip);
     NP_ASSERT_NOT_NULL(uip);
     NP_ASSERT_NOT_NULL(sip);
-    saddr_c = num_to_string((gchar *) & saddr, G_SOCKET_FAMILY_IPV4);
-    daddr_c = num_to_string((gchar *) & daddr, G_SOCKET_FAMILY_IPV4);
-    NP_ASSERT_STR_EQUAL(saddr_c, lip);
-    NP_ASSERT_STR_EQUAL(saddr_c, sip);
-    NP_ASSERT_STR_EQUAL(daddr_c, uip);
 
-    g_free(saddr_c);
-    g_free(daddr_c);
-    g_free(lip);
-    g_free(sip);
-    g_free(uip);
+    NP_ASSERT(((struct sockaddr_in *) lip)->sin_addr.s_addr == htonl(TEST_SADDR));
+    NP_ASSERT(((struct sockaddr_in *) sip)->sin_addr.s_addr == htonl(TEST_SADDR));
+    NP_ASSERT(((struct sockaddr_in *) uip)->sin_addr.s_addr == htonl(TEST_DADDR));
+
     g_object_unref(flow);
     g_object_unref(table);
 }
@@ -1180,17 +1172,11 @@ void test_flow_properties_reversed()
     NP_ASSERT_NOT_NULL(lip);
     NP_ASSERT_NOT_NULL(uip);
     NP_ASSERT_NOT_NULL(sip);
-    saddr_c = num_to_string((gchar *) & saddr, G_SOCKET_FAMILY_IPV4);
-    daddr_c = num_to_string((gchar *) & daddr, G_SOCKET_FAMILY_IPV4);
-    NP_ASSERT_STR_EQUAL(saddr_c, lip);
-    NP_ASSERT_STR_EQUAL(saddr_c, sip);
-    NP_ASSERT_STR_EQUAL(daddr_c, uip);
 
-    g_free(saddr_c);
-    g_free(daddr_c);
-    g_free(lip);
-    g_free(sip);
-    g_free(uip);
+    NP_ASSERT(((struct sockaddr_in *) lip)->sin_addr.s_addr == htonl(TEST_SADDR));
+    NP_ASSERT(((struct sockaddr_in *) sip)->sin_addr.s_addr == htonl(TEST_SADDR));
+    NP_ASSERT(((struct sockaddr_in *) uip)->sin_addr.s_addr == htonl(TEST_DADDR));
+
     g_object_unref(flow);
     g_object_unref(table);
 }
@@ -1243,17 +1229,17 @@ void test_flow_properties_ipv6()
     NP_ASSERT_NOT_NULL(lip);
     NP_ASSERT_NOT_NULL(uip);
     NP_ASSERT_NOT_NULL(sip);
-    saddr_c = num_to_string(test_ip6src, G_SOCKET_FAMILY_IPV6);
-    daddr_c = num_to_string(test_ip6dst, G_SOCKET_FAMILY_IPV6);
-    NP_ASSERT_STR_EQUAL(saddr_c, lip);
-    NP_ASSERT_STR_EQUAL(daddr_c, uip);
-    NP_ASSERT_STR_EQUAL(saddr_c, sip);
 
-    g_free(saddr_c);
-    g_free(daddr_c);
-    g_free(lip);
-    g_free(sip);
-    g_free(uip);
+    NP_ASSERT(memcmp
+              (&((struct sockaddr_in6 *) lip)->sin6_addr, test_ip6src,
+               sizeof(test_ip6src)) == 0);
+    NP_ASSERT(memcmp
+              (&((struct sockaddr_in6 *) sip)->sin6_addr, test_ip6src,
+               sizeof(test_ip6src)) == 0);
+    NP_ASSERT(memcmp
+              (&((struct sockaddr_in6 *) uip)->sin6_addr, test_ip6dst,
+               sizeof(test_ip6dst)) == 0);
+
     g_object_unref(flow);
     g_object_unref(table);
 }
@@ -1307,17 +1293,17 @@ void test_flow_properties_ipv6_reversed()
     NP_ASSERT_NOT_NULL(lip);
     NP_ASSERT_NOT_NULL(uip);
     NP_ASSERT_NOT_NULL(sip);
-    saddr_c = num_to_string(test_ip6src, G_SOCKET_FAMILY_IPV6);
-    daddr_c = num_to_string(test_ip6dst, G_SOCKET_FAMILY_IPV6);
-    NP_ASSERT_STR_EQUAL(saddr_c, lip);
-    NP_ASSERT_STR_EQUAL(daddr_c, uip);
-    NP_ASSERT_STR_EQUAL(saddr_c, sip);
 
-    g_free(saddr_c);
-    g_free(daddr_c);
-    g_free(lip);
-    g_free(sip);
-    g_free(uip);
+    NP_ASSERT(memcmp
+              (&((struct sockaddr_in6 *) lip)->sin6_addr, test_ip6src,
+               sizeof(test_ip6src)) == 0);
+    NP_ASSERT(memcmp
+              (&((struct sockaddr_in6 *) sip)->sin6_addr, test_ip6src,
+               sizeof(test_ip6src)) == 0);
+    NP_ASSERT(memcmp
+              (&((struct sockaddr_in6 *) uip)->sin6_addr, test_ip6dst,
+               sizeof(test_ip6dst)) == 0);
+
     g_object_unref(flow);
     g_object_unref(table);
 }
@@ -1360,14 +1346,12 @@ void test_flow_table_properties()
 void flow_print_protocol(GInetFlow * flow)
 {
     guint protocol;
-    gchar *lip;
+    struct sockaddr_storage *lip;
 
     NP_ASSERT_NOT_NULL(flow);
     g_object_get(flow, "protocol", &protocol, "lip", &lip, NULL);
     NP_ASSERT((protocol == IP_PROTOCOL_TCP) || (protocol == IP_PROTOCOL_UDP));
     NP_ASSERT_NOT_NULL(lip);
-
-    g_free(lip);
 }
 
 void test_flow_foreach()


### PR DESCRIPTION
The inet_ntop and inet_pton required to fetch IP addresses
is prohibitively expensive - this commit changes the serverip,
lip and uip parameters to return a pointer to a struct
sockaddr_storage with the address. This pointer is only
valid while the user has ownership of the GInetFlow object.