### PR TITLE
Prevent ref count assertion error

### DIFF
--- a/ginetflow.c
+++ b/ginetflow.c
@@ -740,8 +740,7 @@ static void g_inet_flow_finalize(GObject * object)
     GInetFlow *flow = G_INET_FLOW(object);
     int index = find_expiry_index(flow->lifetime);
     g_queue_unlink(flow->table->expire_queue[index], &flow->list);
-    /* This might not be safe - we'll get called as the hash table is destroyed */
-    g_hash_table_remove(flow->table->table, flow);
+    g_hash_table_steal(flow->table->table, flow);
     G_OBJECT_CLASS(g_inet_flow_parent_class)->finalize(object);
 }
 


### PR DESCRIPTION
when an expired flow is unrefed, g_inet_flow_finalize() will call
g_hash_table_remove(), which will also call the destroy funciton,
g_object_unref, causing the second unref to generate an assertion
erroe due to ref count not being greater than 0.

Replace g_hash_table_remove() with g_hash_table_steal() so that
the key and value can ve removed without  calling the key and value
destroy functions.